### PR TITLE
Fix function names and ping cog

### DIFF
--- a/Cogs/halo.py
+++ b/Cogs/halo.py
@@ -15,7 +15,7 @@ class halonews(commands.Cog, name="reddit halo news"):
                     description = "Shows the top ten posts on /r/halo")
     #Function that will post the top 10 posts from /r/halo
     @commands.cooldown(1, 2, commands.BucketType.member)
-    async def energynews(self, ctx):
+    async def halonews(self, ctx):
         for post in hot_posts:
             message = await ctx.send(post.title)
             await message.edit(content=f" • " + post.title)

--- a/Cogs/nba.py
+++ b/Cogs/nba.py
@@ -15,7 +15,7 @@ class nbanews(commands.Cog, name="reddit nba news"):
                     description = "Shows the top ten posts on /r/nba")
     #Function that will post the top 10 posts from /r/nba
     @commands.cooldown(1, 2, commands.BucketType.member)
-    async def energynews(self, ctx):
+    async def nbanews(self, ctx):
         for post in hot_posts:
             message = await ctx.send(post.title)
             await message.edit(content=f" • " + post.title)

--- a/Cogs/ping.py
+++ b/Cogs/ping.py
@@ -2,20 +2,21 @@ import discord
 from discord.ext import commands
 import time
 
-
 class PingCog(commands.Cog, name="ping command"):
-	def __init__(self, bot:commands.bot):
-		self.bot = bot
-        
-	@commands.command(name = "ping",
-					usage="",
-					description = "Display the bot's ping.")
-	@commands.cooldown( 1, .00002, commands.BucketType.member)
-	async def ping(self, ctx):
-		before = time.monotonic()
-		message = await ctx.send("🏓 Pong !")
-		ping = (time.monotonic() - before) * 1000
-		await message.edit(content=f"🏓 Pong !  `{int(ping)} ms`")
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
 
-def setup(bot:commands.Bot):
-	bot.add_cog(PingCog(bot))
+    @commands.command(name="ping",
+                      usage="",
+                      description="Display the bot's ping.")
+    @commands.cooldown(1, 0.00002, commands.BucketType.member)
+    async def ping(self, ctx):
+        before = time.monotonic()
+        message = await ctx.send("🏓 Pong !")
+        ping = (time.monotonic() - before) * 1000
+        await message.edit(content=f"🏓 Pong !  `{int(ping)} ms`")
+
+
+def setup(bot: commands.Bot):
+    bot.add_cog(PingCog(bot))
+

--- a/Cogs/soccer.py
+++ b/Cogs/soccer.py
@@ -15,7 +15,7 @@ class soccernews(commands.Cog, name="reddit soccer news"):
                     description = "Shows the top ten posts on /r/soccer")
     #Function that will post the top 10 posts from /r/soccer
     @commands.cooldown(1, 2, commands.BucketType.member)
-    async def energynews(self, ctx):
+    async def soccernews(self, ctx):
         for post in hot_posts:
             message = await ctx.send(post.title)
             await message.edit(content=f" • " + post.title)

--- a/Cogs/wow.py
+++ b/Cogs/wow.py
@@ -15,7 +15,7 @@ class wownews(commands.Cog, name="reddit wow news"):
                     description = "Shows the top ten posts on /r/wow")
     #Function that will post the top 10 posts from /r/wow
     @commands.cooldown(1, 2, commands.BucketType.member)
-    async def energynews(self, ctx):
+    async def wownews(self, ctx):
         for post in hot_posts:
             message = await ctx.send(post.title)
             await message.edit(content=f" • " + post.title)


### PR DESCRIPTION
## Summary
- fix `PingCog` initializer annotation and indentation
- rename misnamed command handlers in halo, nba, soccer, and wow cogs
- add trailing newlines for cleaner diffs

## Testing
- `python -m py_compile $(ls Cogs/*.py) main.py`

------
https://chatgpt.com/codex/tasks/task_e_68719704e5c88332a424b758b064ec28